### PR TITLE
Remove dependency on potentially vulnerable merge package

### DIFF
--- a/lib/exec-sh.js
+++ b/lib/exec-sh.js
@@ -1,5 +1,4 @@
 var cp = require('child_process')
-var merge = require('merge')
 
 var defSpawnOptions = { stdio: 'inherit' }
 
@@ -41,7 +40,7 @@ function execSh (command, options, callback) {
     options = defSpawnOptions
   } else {
     options = options || {}
-    options = merge(true, defSpawnOptions, options)
+    options = Object.assign({}, defSpawnOptions, options)
     callback = callback || function () {}
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1910,11 +1910,6 @@
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
-    "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
-    },
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "url": "https://github.com/tsertkov/exec-sh/issues"
   },
   "dependencies": {
-    "merge": "^1.2.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.1",

--- a/test/exec-sh.js
+++ b/test/exec-sh.js
@@ -86,6 +86,24 @@ describe('exec-sh', function () {
       assert.deepEqual(spawn.getCall(0).args[2], expectedOptions)
     })
 
+    it('should allow passing nested environment options', function () {
+      var options = {
+        env: {
+          key1: 'value 1',
+          key2: 'value 2'
+        }
+      }
+      var expectedOptions = {
+        env: {
+          key1: 'value 1',
+          key2: 'value 2'
+        },
+        stdio: 'inherit'
+      }
+      execSh('command', options)
+      assert.deepEqual(spawn.getCall(0).args[2], expectedOptions)
+    })
+
     it("should accept optional 'callback' parameter", function () {
       var callback = sinon.spy()
       execSh('command', callback)

--- a/test/exec-sh.js
+++ b/test/exec-sh.js
@@ -2,7 +2,6 @@
 var execSh = require('..')
 var assert = require('assert')
 var sinon = require('sinon')
-var merge = require('merge')
 var cp = require('child_process')
 
 describe('exec-sh', function () {
@@ -68,19 +67,23 @@ describe('exec-sh', function () {
     })
 
     it('should merge defaults with options', function () {
-      execSh('command')
-      var defOptionsClone = merge(true, spawn.getCall(0).args[2])
       var options = { key: 'value' }
-
+      var expectedOptions = {
+        key: 'value',
+        stdio: 'inherit'
+      }
       execSh('command', options)
-      assert.deepEqual(spawn.getCall(1).args[2], merge(true, defOptionsClone, options))
+      assert.deepEqual(spawn.getCall(0).args[2], expectedOptions)
+    })
 
-      // change value of the fist property in default options to null
-      assert.ok(Object.keys(defOptionsClone).length > 0)
-      defOptionsClone[Object.keys(defOptionsClone)[0]] = null
-
-      execSh('command', defOptionsClone)
-      assert.deepEqual(spawn.getCall(2).args[2], defOptionsClone)
+    it('should allow overriding default options', function () {
+      var options = { foo: 'bar', stdio: null }
+      var expectedOptions = {
+        foo: 'bar',
+        stdio: null
+      }
+      execSh('command', options)
+      assert.deepEqual(spawn.getCall(0).args[2], expectedOptions)
     })
 
     it("should accept optional 'callback' parameter", function () {


### PR DESCRIPTION
The `merge` package has a disclosed security vulnerability, see https://hackerone.com/reports/381194.

It appears the package has been effectively abandoned, as the last update was four years ago, the website mentioned in the docs now has a for-sale page and there was no response to the security report.

Since the use here is reasonably simple, I think it's sufficient to use Object.assign instead of the package, which should avoid any fun and games with polluting the prototype of Object.