### PR TITLE
Fix a vulnerability in 'merge' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/tsertkov/exec-sh/issues"
   },
   "dependencies": {
-    "merge": "^1.2.0"
+    "merge": "^1.2.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.1",


### PR DESCRIPTION
Fixed a [vulnerability](https://hackerone.com/reports/381194) in the 'merge' request module by upgrading to the latest version of the package.

Please release as a new v0.2.3 version.