### PR TITLE
Convert var to const & let

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -1,4 +1,4 @@
-var execSh = require('../')
+const execSh = require('../')
 
 // run interactive bash shell
 execSh('echo ola && bash', { cwd: '/home' }, function (err) {

--- a/lib/exec-sh.js
+++ b/lib/exec-sh.js
@@ -1,6 +1,6 @@
-var cp = require('child_process')
+const cp = require('child_process')
 
-var defSpawnOptions = { stdio: 'inherit' }
+const defSpawnOptions = { stdio: 'inherit' }
 
 /**
  * @summary Get shell program meta for current platform
@@ -44,10 +44,10 @@ function execSh (command, options, callback) {
     callback = callback || function () {}
   }
 
-  var child
-  var stdout = ''
-  var stderr = ''
-  var shell = getShell()
+  let child
+  let stdout = ''
+  let stderr = ''
+  const shell = getShell()
 
   try {
     child = cp.spawn(shell.cmd, [shell.arg, command], options)
@@ -70,7 +70,7 @@ function execSh (command, options, callback) {
 
   child.on('close', function (code) {
     if (code) {
-      var e = new Error('Shell command exit with non zero code: ' + code)
+      const e = new Error('Shell command exit with non zero code: ' + code)
       e.code = code
       callback(e, stdout, stderr)
     } else {

--- a/test/exec-sh.js
+++ b/test/exec-sh.js
@@ -1,8 +1,8 @@
 /* global describe, it, beforeEach, afterEach */
-var execSh = require('..')
-var assert = require('assert')
-var sinon = require('sinon')
-var cp = require('child_process')
+const execSh = require('..')
+const assert = require('assert')
+const sinon = require('sinon')
+const cp = require('child_process')
 
 describe('exec-sh', function () {
   describe('module.exports', function () {
@@ -16,7 +16,7 @@ describe('exec-sh', function () {
   })
 
   describe('#execSh() arguments', function () {
-    var spawn, exitCode, stream
+    let spawn, exitCode, stream
 
     stream = {
       on: function (e, c) {
@@ -67,8 +67,8 @@ describe('exec-sh', function () {
     })
 
     it('should merge defaults with options', function () {
-      var options = { key: 'value' }
-      var expectedOptions = {
+      const options = { key: 'value' }
+      const expectedOptions = {
         key: 'value',
         stdio: 'inherit'
       }
@@ -77,8 +77,8 @@ describe('exec-sh', function () {
     })
 
     it('should allow overriding default options', function () {
-      var options = { foo: 'bar', stdio: null }
-      var expectedOptions = {
+      const options = { foo: 'bar', stdio: null }
+      const expectedOptions = {
         foo: 'bar',
         stdio: null
       }
@@ -87,13 +87,13 @@ describe('exec-sh', function () {
     })
 
     it('should allow passing nested environment options', function () {
-      var options = {
+      const options = {
         env: {
           key1: 'value 1',
           key2: 'value 2'
         }
       }
-      var expectedOptions = {
+      const expectedOptions = {
         env: {
           key1: 'value 1',
           key2: 'value 2'
@@ -105,14 +105,14 @@ describe('exec-sh', function () {
     })
 
     it("should accept optional 'callback' parameter", function () {
-      var callback = sinon.spy()
+      const callback = sinon.spy()
       execSh('command', callback)
       execSh('command', { key: 'value' }, callback)
       sinon.assert.callCount(callback, 2)
     })
 
     it("should use 'cmd /C' command prefix on windows", function () {
-      var platform = process.platform
+      const platform = process.platform
       Object.defineProperty(process, 'platform', { value: 'win32' })
       execSh('command')
       Object.defineProperty(process, 'platform', { value: platform })
@@ -122,7 +122,7 @@ describe('exec-sh', function () {
     })
 
     it("should use 'sh -c' command prefix on *nix", function () {
-      var platform = process.platform
+      const platform = process.platform
       process.platform = 'linux'
       execSh('command')
       process.platform = platform


### PR DESCRIPTION
Dropping support for node < 6 with this change.
Fixing no-var warnings from standard (eslint).